### PR TITLE
Model data fetching

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,13 @@ FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LibXSPEC_jll = "50917eeb-3e3c-5f3a-99bd-93e1c30e1561"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
+MemoizedMethods = "2f808968-54ae-4603-8d72-6e67d20f0a1c"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Surrogates = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
+
+[compat]
+LibXSPEC_jll = "0.1.9"

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -69,6 +69,8 @@ XS_DiskLine
 XS_PhotoelectricAbsorption
 XS_WarmAbsorption
 XS_CalculateFlux
+XS_KerrDisk
+XS_KyrLine
 ```
 
 ### Wrapping new XSPEC models

--- a/src/SpectralFitting.jl
+++ b/src/SpectralFitting.jl
@@ -4,12 +4,15 @@ using LibXSPEC_jll
 
 import Base
 import Printf
+import Downloads
+import Pkg.MiniProgressBars: MiniProgressBar, start_progress, end_progress, show_progress
 
 using FITSIO
 using SparseArrays
 using Surrogates
 using ForwardDiff
 using PreallocationTools
+using MemoizedMethods
 
 import Crayons
 import Parameters: @with_kw
@@ -36,6 +39,7 @@ include("file-io/binning-utilities.jl")
 include("file-io/parsing-utilities.jl")
 include("file-io/no-associated-mission.jl")
 include("file-io/fits-loading.jl")
+include("file-io/model-data-io.jl")
 
 include("fitting.jl")
 include("plotting-recipes.jl")
@@ -50,6 +54,8 @@ include("julia-models/model-utilities.jl")
 include("julia-models/additive.jl")
 
 function __init__()
+    # check if we have the minimum model data already
+    _check_model_directory_present()
     # init HEASOFT
     ccall((:FNINIT, libXSFunctions), Cvoid, ())
 end

--- a/src/ccall-wrapper.jl
+++ b/src/ccall-wrapper.jl
@@ -88,6 +88,9 @@ macro xspecmodel(model_kind, func_name, model)
             init_string = "",
         )
             @assert length(flux) + 1 == length(energy)
+            if !_is_model_data_downloaded(m)
+                error("Model data for $(model_base_name(M)) is not present! Requisite model data may be fetched with `download_model_data`.")
+            end
             if length(UNTRACKED_ERROR) < length(flux)
                 resize_untracked_error(length(flux))
             end

--- a/src/ccall-wrapper.jl
+++ b/src/ccall-wrapper.jl
@@ -89,7 +89,7 @@ macro xspecmodel(model_kind, func_name, model)
         )
             @assert length(flux) + 1 == length(energy)
             if !_is_model_data_downloaded(m)
-                error("Model data for $(model_base_name(M)) is not present! Requisite model data may be fetched with `download_model_data`.")
+                error("Model data for $(model_base_name(m)) is not present! Requisite model data may be fetched with `download_model_data`.")
             end
             if length(UNTRACKED_ERROR) < length(flux)
                 resize_untracked_error(length(flux))

--- a/src/file-io/model-data-io.jl
+++ b/src/file-io/model-data-io.jl
@@ -1,0 +1,90 @@
+const MODEL_DATA_PATH = joinpath(LibXSPEC_jll.artifact_dir, "spectral",  "modelData")
+MODEL_TO_MODEL_DATA_MAP = Dict{Symbol,Vector{String}}()
+MODEL_DATA_PRESENT_CACHE = Dict{Symbol,Bool}()
+
+function download_minimal_model_data()
+
+end
+
+function _needs_model_data(M::Type{<:AbstractSpectralModel}, filenames::String...)
+    s = Base.typename(M).name
+    if s in keys(MODEL_TO_MODEL_DATA_MAP)
+        push!(MODEL_TO_MODEL_DATA_MAP[s], filenames...)
+    else
+        MODEL_TO_MODEL_DATA_MAP[s] = collect(filenames)
+    end
+end
+
+_is_model_data_downloaded(M::Type{<:AbstractSpectralModel}) = _is_model_data_downloaded(implementation(M), M)
+_is_model_data_downloaded(::AbstractSpectralModelImplementation, _)::Bool = true
+function _is_model_data_downloaded(::XSPECImplementation, M)::Bool
+    s = Base.typename(M).name
+    if get(MODEL_DATA_PRESENT_CACHE, s, false)
+        return true
+    else
+        return _check_model_files_and_add_to_cache(s)
+    end
+end
+
+function _check_model_files_and_add_to_cache(s::Symbol)
+    # get the filenames we need
+    filenames = get(MODEL_TO_MODEL_DATA_MAP, s, nothing)
+    if !isnothing(filenames)
+        if !all(i -> ispath(joinpath(MODEL_DATA_PATH, i)), filenames)
+            return false
+        end
+    end
+    # cache true
+    MODEL_DATA_PRESENT_CACHE[s] = true
+    return true
+end
+
+function _check_model_directory_present()
+    if !ispath(MODEL_DATA_PATH)
+        @warn "No model data directory found. Use `SpectralFitting.download_minimal_model_data()` to populate."
+    end
+end
+
+function _download_from_archive(src, dest; progress=true, io::IO=Core.stdout)
+    url = "http://www.star.bris.ac.uk/fbaker/XSPEC-model-data/$src"
+    pg = if progress
+        bar = MiniProgressBar(header="Downloading: $src", color=Base.info_color())
+        start_progress(io, bar)
+        (total, now) -> begin
+            bar.max = total
+            bar.current = now
+            show_progress(io, bar)
+        end
+    else
+        (_, _) -> nothing
+    end
+    Downloads.download(
+        url, dest;
+        progress = pg
+    )
+    end_progress(io, bar)
+end
+
+download_model_data(::M; kwargs...) where {M<:AbstractSpectralModel} = download_model_data(M; kwargs...)
+function download_model_data(M::Type{<:AbstractSpectralModel}; kwargs...)
+    if _is_model_data_downloaded(M)
+        @warn "Model data for $(model_base_name(M)) is already downloaded."
+        return false
+    end
+
+    # check model data directory exists
+    if !ispath(MODEL_DATA_PATH)
+        mkdir(MODEL_DATA_PATH)
+    end
+
+    s = Base.typename(M).name
+    for src in MODEL_TO_MODEL_DATA_MAP[s]
+        dest = joinpath(MODEL_DATA_PATH, src)
+        if !ispath(dest)
+            _download_from_archive(src, dest; kwargs...)
+        end
+    end
+    true
+end
+
+export download_model_data

--- a/src/file-io/model-data-io.jl
+++ b/src/file-io/model-data-io.jl
@@ -1,4 +1,4 @@
-const MODEL_DATA_PATH = joinpath(LibXSPEC_jll.artifact_dir, "spectral",  "modelData")
+MODEL_DATA_PATH = joinpath(LibXSPEC_jll.artifact_dir, "spectral",  "modelData")
 MODEL_TO_MODEL_DATA_MAP = Dict{Symbol,Vector{String}}()
 MODEL_DATA_PRESENT_CACHE = Dict{Symbol,Bool}()
 
@@ -74,16 +74,20 @@ function download_model_data(M::Type{<:AbstractSpectralModel}; kwargs...)
 
     # check model data directory exists
     if !ispath(MODEL_DATA_PATH)
+        # else make it
         mkdir(MODEL_DATA_PATH)
     end
 
     s = Base.typename(M).name
+    @info "Checking model data for $M."
     for src in MODEL_TO_MODEL_DATA_MAP[s]
         dest = joinpath(MODEL_DATA_PATH, src)
         if !ispath(dest)
             _download_from_archive(src, dest; kwargs...)
+            @info "$src downloaded"
         end
     end
+    @info "All requisite model data for $M downloaded."
     true
 end
 

--- a/src/file-io/model-data-io.jl
+++ b/src/file-io/model-data-io.jl
@@ -6,7 +6,7 @@ function download_minimal_model_data()
 
 end
 
-function _needs_model_data(M::Type{<:AbstractSpectralModel}, filenames::String...)
+function _register_model_data(M::Type{<:AbstractSpectralModel}, filenames::String...)
     s = Base.typename(M).name
     if s in keys(MODEL_TO_MODEL_DATA_MAP)
         push!(MODEL_TO_MODEL_DATA_MAP[s], filenames...)

--- a/src/julia-models/additive.jl
+++ b/src/julia-models/additive.jl
@@ -7,7 +7,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, PowerLaw())
+invokemodel(energy, PowerLaw())
 ```
 
 ```
@@ -57,7 +57,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, BlackBody())
+invokemodel(energy, BlackBody())
 ```
 
 ```

--- a/src/surrogate-models.jl
+++ b/src/surrogate-models.jl
@@ -185,7 +185,7 @@ Creates and optimizes a surrogate model of type `S` for `model`, using [`wrap_mo
 and  [`optimize_accuracy!`](@ref) for `optimization_samples` iterations. Model is initially
 seeded with `seed_samples` points prior to optimization.
 
-!!! note
+!!! warning
     Additive models integrate energies to calculate flux, which surrogate models are currently not
     capable of. Results for Additive models likely to be inaccurate. This will be patched in a future
     version.

--- a/src/xspec-models/additive.jl
+++ b/src/xspec-models/additive.jl
@@ -124,57 +124,127 @@ invokemodel(energy, XS_BremsStrahlung())
     T::F2 = FitParam(7.0)
 end
 
-# broken
-# symbol lookup error: lib/libXS.so: undefined symbol: _gfortran_string_len_trim
-# @xspecmodel Additive :C_kerrdisk struct XS_KerrDisk{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10}
-#     "Normalisation."
-#     K::F1 = FitParam(1.0)
-#     "Rest frame line energy (keV)."
-#     lineE::F2 = FrozenFitParam(6.4)
-#     "Emissivity index for inner disk."
-#     index1::F3 = FrozenFitParam(3.0)
-#     "Emissivity index for outer disk."
-#     index2::F4 = FrozenFitParam(3.0)
-#     "Break radius seperating inner and outer disk (gᵣ)."
-#     break_r::F5 = FrozenFitParam(6.0)
-#     "Dimensionless black hole spin."
-#     a::F6 = FitParam(0.998)
-#     "Disk inclination angle to line of sight (degrees)."
-#     incl::F7 = FrozenFitParam(30.0)
-#     "Inner radius of the disk in units of rₘₛ."
-#     inner_r::F8 = FrozenFitParam(1.0)
-#     "Outer radius of the disk in units of rₘₛ."
-#     outer_r::F9 = FrozenFitParam(400.0)
-#     "Redshift."
-#     z::F10 = FrozenFitParam(0.0)
-# end
 
-# broken
-# symbol lookup error: lib/libXSFunctions.so: undefined symbol: _gfortran_st_write
-# @xspecmodel Additive :C_kyrline struct XS_Kyrline{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12}
-#     "Normalisation."
-#     K::F1 = FitParam(1.0)
-#     "Dimensionless black hole spin."
-#     a::F2 = FitParam(0.998)
-#     "Observer inclination (0 is on pole, degrees)."
-#     θ_obs::F3 = FitParam(30.0)
-#     "Inner radius of the disk in units of GM/c²"
-#     inner_r::F4 = FrozenFitParam(1.0)
-#     "0: integrate from rᵢₙ. 1: integrate from rₘₛ."
-#     ms_flag::F5 = FrozenFitParam(1)
-#     "Outer radius of the disk in units of GM/c²"
-#     outer_r::F6 = FrozenFitParam(400.0)
-#     "Rest frame line energy (keV)."
-#     lineE::F7 = FrozenFitParam(6.4)
-#     α::F8 = FrozenFitParam(3.0)
-#     β::F9 = FrozenFitParam(3.0)
-#     "Break radius seperating inner and outer disk (GM/c²)."
-#     break_r::F10 = FrozenFitParam(400.0)
-#     "Overall Doppler shift."
-#     z::F11 = FrozenFitParam(0.0)
-#     "0: isotropic emission, 1: Laor's limb darkening, 2: Haard's limb brightening."
-#     limb::F12 = FrozenFitParam(1)
-# end
+"""
+    XS_KerrDisk(K, lineE, index1, index2, break_r, a, incl, inner_r, outer_r)
+
+$(FIELDS)
+
+# Example
+
+```julia
+energy = collect(range(0.1, 20.0, 100))
+invokemodel(energy, XS_KerrDisk())
+```
+
+```
+                       XS_KerrDisk
+       ┌────────────────────────────────────────┐
+   0.1 │            :                           │
+       │            :                           │
+       │           ::                           │
+       │           : :                          │
+       │           : :                          │
+       │          :  :                          │
+       │          :  :                          │
+       │         :   :                          │
+       │         :   :                          │
+       │        :    :                          │
+       │       .'    :                          │
+       │       :     :                          │
+       │    ..'      :                          │
+       │    :'       :                          │
+     0 │...:'        :..........................│
+       └────────────────────────────────────────┘
+        0                                     20
+                         E (keV)
+```
+"""
+@xspecmodel Additive :C_kerrdisk struct XS_KerrDisk{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10}
+    "Normalisation."
+    K::F1 = FitParam(1.0)
+    "Rest frame line energy (keV)."
+    lineE::F2 = FrozenFitParam(6.4)
+    "Emissivity index for inner disk."
+    index1::F3 = FrozenFitParam(3.0)
+    "Emissivity index for outer disk."
+    index2::F4 = FrozenFitParam(3.0)
+    "Break radius seperating inner and outer disk (gᵣ)."
+    break_r::F5 = FrozenFitParam(6.0)
+    "Dimensionless black hole spin."
+    a::F6 = FitParam(0.998)
+    "Disk inclination angle to line of sight (degrees)."
+    incl::F7 = FrozenFitParam(30.0)
+    "Inner radius of the disk in units of rₘₛ."
+    inner_r::F8 = FrozenFitParam(1.0)
+    "Outer radius of the disk in units of rₘₛ."
+    outer_r::F9 = FrozenFitParam(400.0)
+    "Redshift."
+    z::F10 = FrozenFitParam(0.0)
+end
+_register_model_data(XS_KerrDisk, "kerrtable.fits")
+
+
+"""
+    XS_KyrLine(K, a, θ_obs, inner_r, ms_flag, outer_r, lineE, α, β, break_r, z, limb)
+
+$(FIELDS)
+
+# Example
+
+```julia
+energy = collect(range(0.1, 20.0, 100))
+invokemodel(energy, XS_KyrLine())
+```
+
+```
+                       XS_KyrLine
+       ┌────────────────────────────────────────┐
+   0.1 │                                        │
+       │            ::                          │
+       │           .':                          │
+       │           : :                          │
+       │           : :                          │
+       │          :  :                          │
+       │          :  :                          │
+       │         :   :                          │
+       │        .:   :                          │
+       │        :    :                          │
+       │       .'    :                          │
+       │       :     :                          │
+       │     .:      :                          │
+       │    .:       :                          │
+     0 │...:'        :..........................│
+       └────────────────────────────────────────┘
+        0                                     20
+```
+"""
+@xspecmodel Additive :C_kyrline struct XS_KyrLine{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12}
+    "Normalisation."
+    K::F1 = FitParam(1.0)
+    "Dimensionless black hole spin."
+    a::F2 = FitParam(0.998)
+    "Observer inclination (0 is on pole, degrees)."
+    θ_obs::F3 = FitParam(30.0)
+    "Inner radius of the disk in units of GM/c²"
+    inner_r::F4 = FrozenFitParam(1.0)
+    "0: integrate from rᵢₙ. 1: integrate from rₘₛ."
+    ms_flag::F5 = FrozenFitParam(1)
+    "Outer radius of the disk in units of GM/c²"
+    outer_r::F6 = FrozenFitParam(400.0)
+    "Rest frame line energy (keV)."
+    lineE::F7 = FrozenFitParam(6.4)
+    α::F8 = FrozenFitParam(3.0)
+    β::F9 = FrozenFitParam(3.0)
+    "Break radius seperating inner and outer disk (GM/c²)."
+    break_r::F10 = FrozenFitParam(400.0)
+    "Overall Doppler shift."
+    z::F11 = FrozenFitParam(0.0)
+    "0: isotropic emission, 1: Laor's limb darkening, 2: Haard's limb brightening."
+    limb::F12 = FrozenFitParam(1)
+end
+_register_model_data(XS_KyrLine, "KBHline01.fits")
+
 
 """
     XS_Laor(K, lineE, a, inner_r, outer_r, incl)
@@ -277,4 +347,4 @@ invokemodel(energy, XS_DiskLine())
     incl::F6 = FitParam(30.0)
 end
 
-export XS_PowerLaw, XS_BlackBody, XS_BremsStrahlung, XS_Laor, XS_DiskLine
+export XS_PowerLaw, XS_BlackBody, XS_BremsStrahlung, XS_Laor, XS_DiskLine, XS_KerrDisk, XS_KyrLine

--- a/src/xspec-models/additive.jl
+++ b/src/xspec-models/additive.jl
@@ -7,7 +7,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, XS_PowerLaw())
+invokemodel(energy, XS_PowerLaw())
 ```
 
 ```
@@ -49,7 +49,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, XS_BlackBody())
+invokemodel(energy, XS_BlackBody())
 ```
 
 ```
@@ -91,7 +91,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, XS_BremsStrahlung())
+invokemodel(energy, XS_BremsStrahlung())
 ```
 
 ```
@@ -185,7 +185,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 10.0, 100))
-invokeflux(energy, XS_Laor())
+invokemodel(energy, XS_Laor())
 ```
 
 ```
@@ -235,7 +235,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(4.0, 8.0, 100))
-invokeflux(energy, XS_DiskLine())
+invokemodel(energy, XS_DiskLine())
 ```
 
 ```

--- a/src/xspec-models/additive.jl
+++ b/src/xspec-models/additive.jl
@@ -126,28 +126,28 @@ end
 
 # broken
 # symbol lookup error: lib/libXS.so: undefined symbol: _gfortran_string_len_trim
-# @xspecmodel Additive :C_kerrdisk struct XS_KerrDisk{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10}
-#     "Normalisation."
-#     K::F1 = FitParam(1.0)
-#     "Rest frame line energy (keV)."
-#     lineE::F2 = FrozenFitParam(6.4)
-#     "Emissivity index for inner disk."
-#     index1::F3 = FrozenFitParam(3.0)
-#     "Emissivity index for outer disk."
-#     index2::F4 = FrozenFitParam(3.0)
-#     "Break radius seperating inner and outer disk (gᵣ)."
-#     break_r::F5 = FrozenFitParam(6.0)
-#     "Dimensionless black hole spin."
-#     a::F6 = FitParam(0.998)
-#     "Disk inclination angle to line of sight (degrees)."
-#     incl::F7 = FrozenFitParam(30.0)
-#     "Inner radius of the disk in units of rₘₛ."
-#     inner_r::F8 = FrozenFitParam(1.0)
-#     "Outer radius of the disk in units of rₘₛ."
-#     outer_r::F9 = FrozenFitParam(400.0)
-#     "Redshift."
-#     z::F10 = FrozenFitParam(0.0)
-# end
+@xspecmodel Additive :C_kerrdisk struct XS_KerrDisk{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10}
+    "Normalisation."
+    K::F1 = FitParam(1.0)
+    "Rest frame line energy (keV)."
+    lineE::F2 = FrozenFitParam(6.4)
+    "Emissivity index for inner disk."
+    index1::F3 = FrozenFitParam(3.0)
+    "Emissivity index for outer disk."
+    index2::F4 = FrozenFitParam(3.0)
+    "Break radius seperating inner and outer disk (gᵣ)."
+    break_r::F5 = FrozenFitParam(6.0)
+    "Dimensionless black hole spin."
+    a::F6 = FitParam(0.998)
+    "Disk inclination angle to line of sight (degrees)."
+    incl::F7 = FrozenFitParam(30.0)
+    "Inner radius of the disk in units of rₘₛ."
+    inner_r::F8 = FrozenFitParam(1.0)
+    "Outer radius of the disk in units of rₘₛ."
+    outer_r::F9 = FrozenFitParam(400.0)
+    "Redshift."
+    z::F10 = FrozenFitParam(0.0)
+end
 
 # broken
 # symbol lookup error: lib/libXSFunctions.so: undefined symbol: _gfortran_st_write
@@ -225,6 +225,7 @@ invokemodel(energy, XS_Laor())
     "Disk inclination angle to line of sight (degrees, 0 is pole on)."
     incl::F6 = FitParam(30.0)
 end
+_needs_model_data(XS_Laor, "ari.mod")
 
 """
     XS_DiskLine(K, lineE, β, inner_r, outer_r, incl)

--- a/src/xspec-models/additive.jl
+++ b/src/xspec-models/additive.jl
@@ -126,28 +126,28 @@ end
 
 # broken
 # symbol lookup error: lib/libXS.so: undefined symbol: _gfortran_string_len_trim
-@xspecmodel Additive :C_kerrdisk struct XS_KerrDisk{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10}
-    "Normalisation."
-    K::F1 = FitParam(1.0)
-    "Rest frame line energy (keV)."
-    lineE::F2 = FrozenFitParam(6.4)
-    "Emissivity index for inner disk."
-    index1::F3 = FrozenFitParam(3.0)
-    "Emissivity index for outer disk."
-    index2::F4 = FrozenFitParam(3.0)
-    "Break radius seperating inner and outer disk (gᵣ)."
-    break_r::F5 = FrozenFitParam(6.0)
-    "Dimensionless black hole spin."
-    a::F6 = FitParam(0.998)
-    "Disk inclination angle to line of sight (degrees)."
-    incl::F7 = FrozenFitParam(30.0)
-    "Inner radius of the disk in units of rₘₛ."
-    inner_r::F8 = FrozenFitParam(1.0)
-    "Outer radius of the disk in units of rₘₛ."
-    outer_r::F9 = FrozenFitParam(400.0)
-    "Redshift."
-    z::F10 = FrozenFitParam(0.0)
-end
+# @xspecmodel Additive :C_kerrdisk struct XS_KerrDisk{F1,F2,F3,F4,F5,F6,F7,F8,F9,F10}
+#     "Normalisation."
+#     K::F1 = FitParam(1.0)
+#     "Rest frame line energy (keV)."
+#     lineE::F2 = FrozenFitParam(6.4)
+#     "Emissivity index for inner disk."
+#     index1::F3 = FrozenFitParam(3.0)
+#     "Emissivity index for outer disk."
+#     index2::F4 = FrozenFitParam(3.0)
+#     "Break radius seperating inner and outer disk (gᵣ)."
+#     break_r::F5 = FrozenFitParam(6.0)
+#     "Dimensionless black hole spin."
+#     a::F6 = FitParam(0.998)
+#     "Disk inclination angle to line of sight (degrees)."
+#     incl::F7 = FrozenFitParam(30.0)
+#     "Inner radius of the disk in units of rₘₛ."
+#     inner_r::F8 = FrozenFitParam(1.0)
+#     "Outer radius of the disk in units of rₘₛ."
+#     outer_r::F9 = FrozenFitParam(400.0)
+#     "Redshift."
+#     z::F10 = FrozenFitParam(0.0)
+# end
 
 # broken
 # symbol lookup error: lib/libXSFunctions.so: undefined symbol: _gfortran_st_write
@@ -225,7 +225,7 @@ invokemodel(energy, XS_Laor())
     "Disk inclination angle to line of sight (degrees, 0 is pole on)."
     incl::F6 = FitParam(30.0)
 end
-_needs_model_data(XS_Laor, "ari.mod")
+_register_model_data(XS_Laor, "ari.mod")
 
 """
     XS_DiskLine(K, lineE, β, inner_r, outer_r, incl)

--- a/src/xspec-models/multiplicative.jl
+++ b/src/xspec-models/multiplicative.jl
@@ -7,7 +7,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, XS_PhotoelectricAbsorption())
+invokemodel(energy, XS_PhotoelectricAbsorption())
 ```
 
 ```
@@ -47,7 +47,7 @@ $(FIELDS)
 
 ```julia
 energy = collect(range(0.1, 20.0, 100))
-invokeflux(energy, XS_WarmAbsorption())
+invokemodel(energy, XS_WarmAbsorption())
 ```
 
 ```


### PR DESCRIPTION
Changes to [LibXSPEC_jll](https://github.com/astro-group-bristol/LibXSPEC_jll.jl) now ship light-weight artifacts with all of the bloated model data removed, and fixes issues with undefined symbols in libgfortran.

- These commits add a data fetcher which downloads the requisite model data from the Bristol astro servers.
- Also update documentation for the now fixed models.