### PR TITLE
Rename functions and fields

### DIFF
--- a/src/plotting-recipes.jl
+++ b/src/plotting-recipes.jl
@@ -5,7 +5,7 @@ using RecipesBase
     markersize := 0
     color := :black
     (rate, rateerror) = (d.rate ./ d.energy_bin_widths, d.rateerror ./ d.energy_bin_widths)
-    yerr :=rateerror 
+    yerr := rateerror
     xerr := d.energy_bin_widths ./ 2
     xscale := :log10
     xticks := ([1e-1, 1, 2, 5, 10, 20, 50, 100], [1e-1, 1, 2, 5, 10, 20, 50, 100])

--- a/src/plotting-recipes.jl
+++ b/src/plotting-recipes.jl
@@ -10,6 +10,6 @@ using RecipesBase
     xscale := :log10
     xticks := ([1e-1, 1, 2, 5, 10, 20, 50, 100], [1e-1, 1, 2, 5, 10, 20, 50, 100])
     xlabel := "Energy (keV)"
-    energy = (d.energy_bins_low .+ d.energy_bins_high) ./ 2
+    energy = (d.bins_low .+ d.bins_high) ./ 2
     (energy, rate)
 end

--- a/src/poisson.jl
+++ b/src/poisson.jl
@@ -10,6 +10,6 @@ Derived from likelihood of binomial distributions being the beta function.
 """
 function count_error(k, σ)
     p = Distributions.cdf(Distributions.Normal(), σ)
-    kₑ = gamma_inc_inv(k+1, p, 1-p)
+    kₑ = gamma_inc_inv(k + 1, p, 1 - p)
     abs(k - kₑ)
 end

--- a/src/spectral-datasets/binning-utilities.jl
+++ b/src/spectral-datasets/binning-utilities.jl
@@ -10,7 +10,7 @@ function rebin_flux(flux, current_energy, dest_energy_bins::AbstractVector)
 end
 
 function rebin_flux(flux, current_energy, rm::ResponseMatrix)
-    downsample_rebin(flux, current_energy, rm.energy_bins_high)
+    downsample_rebin(flux, current_energy, rm.bins_high)
 end
 
 function downsample_rebin(input, current_bins, target_bins_high)
@@ -64,9 +64,9 @@ function energy_vector(response::ResponseMatrix{T}) where {T}
 end
 
 function energy_vector(x, T::Type)
-    energy = zeros(T, length(x.energy_bins_low) + 1)
-    energy[1:end-1] .= x.energy_bins_low
-    energy[end] = x.energy_bins_high[end]
+    energy = zeros(T, length(x.bins_low) + 1)
+    energy[1:end-1] .= x.bins_low
+    energy[end] = x.bins_high[end]
     energy
 end
 
@@ -104,24 +104,24 @@ function augmented_energy_channels(channels, rm::ResponseMatrix{T}) where {T}
     @inbounds for (i, c) in enumerate(channels)
         if c ≤ N
             index = findfirst(==(c), rm.channels)
-            Emax[i] = rm.channel_energy_bins_high[index]
-            Emin[i] = rm.channel_energy_bins_low[index]
+            Emax[i] = rm.channel_bins_high[index]
+            Emin[i] = rm.channel_bins_low[index]
         end
     end
     (Emin, Emax)
 end
 
-function energy_to_channel(E, channels, energy_bins_low, energy_bins_high, start)
+function energy_to_channel(E, channels, bins_low, bins_high, start)
     @views energy_to_channel(
         E,
         channels[start:end],
-        energy_bins_low[start:end],
-        energy_bins_high[start:end],
+        bins_low[start:end],
+        bins_high[start:end],
     )
 end
 
-function energy_to_channel(E, channels, energy_bins_low, energy_bins_high)
-    for (c, low_e, high_e) in zip(channels, energy_bins_low, energy_bins_high)
+function energy_to_channel(E, channels, bins_low, bins_high)
+    for (c, low_e, high_e) in zip(channels, bins_low, bins_high)
         if (E ≥ low_e) && (high_e > E)
             return convert(Int, c)
         end

--- a/src/spectral-datasets/dataset-types.jl
+++ b/src/spectral-datasets/dataset-types.jl
@@ -52,7 +52,7 @@ mutable struct SpectralDataset{
     meta::MetaType
     poisson_errors::PoissType
     response::ResponseMatrix{T}
-    ancillary::AncillaryResponse
+    ancillary::AncType
     background::BkgType
 
     channels::Vector{Int}

--- a/src/spectral-datasets/dataset-types.jl
+++ b/src/spectral-datasets/dataset-types.jl
@@ -13,8 +13,8 @@ trim_meta!(::AbstractMetadata, inds) = nothing
 group_meta(::AbstractMetadata, mask, inds) = nothing
 
 struct AncillaryResponse{T}
-    energy_bins_low::Vector{T}
-    energy_bins_high::Vector{T}
+    bins_low::Vector{T}
+    bins_high::Vector{T}
     spec_response::Vector{T}
 end
 
@@ -22,10 +22,10 @@ end
 struct ResponseMatrix{T}
     matrix::SparseMatrixCSC{T,Int}
     channels::Vector{Int}
-    channel_energy_bins_low::Vector{T}
-    channel_energy_bins_high::Vector{T}
-    energy_bins_low::Vector{T}
-    energy_bins_high::Vector{T}
+    channel_bins_low::Vector{T}
+    channel_bins_high::Vector{T}
+    bins_low::Vector{T}
+    bins_high::Vector{T}
 end
 
 # concrete type
@@ -42,8 +42,8 @@ mutable struct SpectralDataset{
     # store high and low seperately
     # incase discontinuous dataset
     # - will there ever be discontinuous bins??
-    energy_bins_low::VecType
-    energy_bins_high::VecType
+    bins_low::VecType
+    bins_high::VecType
 
     _data::VecType
     _errors::VecType

--- a/src/spectral-datasets/dataset-types.jl
+++ b/src/spectral-datasets/dataset-types.jl
@@ -29,24 +29,34 @@ struct ResponseMatrix{T}
 end
 
 # concrete type
-mutable struct SpectralDataset{T,M,P,U,A,B}
+mutable struct SpectralDataset{
+    T,
+    MetaType,
+    PoissType,
+    UnitType,
+    AncType,
+    BkgType,
+    GroupType,
+    VecType,
+}
     # store high and low seperately
     # incase discontinuous dataset
-    energy_bins_low::Vector{T}
-    energy_bins_high::Vector{T}
+    # - will there ever be discontinuous bins??
+    energy_bins_low::VecType
+    energy_bins_high::VecType
 
-    _data::Vector{T}
-    _errors::Vector{T}
-    units::U
+    _data::VecType
+    _errors::VecType
+    units::UnitType
 
-    meta::M
-    poisson_errors::P
+    meta::MetaType
+    poisson_errors::PoissType
     response::ResponseMatrix{T}
-    ancillary::A
-    background::B
+    ancillary::AncillaryResponse
+    background::BkgType
 
     channels::Vector{Int}
-    grouping::Vector{Int}
+    grouping::GroupType
     quality::Vector{Int}
 
     mask::BitVector

--- a/src/spectral-datasets/datasets.jl
+++ b/src/spectral-datasets/datasets.jl
@@ -2,7 +2,7 @@ export mask_bad_channels!, mask_energy!
 
 function SpectralDataset(
     units,
-    spec::OGIP_Spectrum,
+    spec::OGIP_Events,
     rmf::OGIP_RMF,
     arf,
     background,

--- a/src/spectral-datasets/datasets.jl
+++ b/src/spectral-datasets/datasets.jl
@@ -17,7 +17,7 @@ function SpectralDataset(
         spec.stat_error,
         units,
         meta,
-        spec.poisson_error,
+        spec.header.poisson_error,
         rm,
         arf,
         background,
@@ -25,7 +25,7 @@ function SpectralDataset(
         spec.grouping,
         spec.quality,
         BitVector([true for _ in spec.values]),
-        spec.exposure_time,
+        spec.header.exposure_time,
     )
 end
 

--- a/src/spectral-datasets/missions/no-associated-mission.jl
+++ b/src/spectral-datasets/missions/no-associated-mission.jl
@@ -12,7 +12,7 @@ end
 missiontrait(::Type{<:BasicMetadata}) = NoMission()
 
 function SpectralDataset(::NoMission, path, rm_path; T::Type = Float64, units = nothing)
-    spec = OGIP_Events(path; T)
+    spec = OGIP_GroupedEvents(path; T)
     rmf = OGIP_RMF(rm_path; T)
     meta = BasicMetadata(path, rm_path, spec.telescope, spec.instrument)
     _units = if isnothing(units) # if no units given, have to guess them from the data

--- a/src/spectral-datasets/missions/no-associated-mission.jl
+++ b/src/spectral-datasets/missions/no-associated-mission.jl
@@ -12,7 +12,7 @@ end
 missiontrait(::Type{<:BasicMetadata}) = NoMission()
 
 function SpectralDataset(::NoMission, path, rm_path; T::Type = Float64, units = nothing)
-    spec = OGIP_Spectrum(path; T)
+    spec = OGIP_Events(path; T)
     rmf = OGIP_RMF(rm_path; T)
     meta = BasicMetadata(path, rm_path, spec.telescope, spec.instrument)
     _units = if isnothing(units) # if no units given, have to guess them from the data

--- a/src/spectral-datasets/missions/xmm-newton-mission.jl
+++ b/src/spectral-datasets/missions/xmm-newton-mission.jl
@@ -24,7 +24,7 @@ function SpectralDataset(
     arf_path;
     T::Type = Float64,
 ) where {D}
-    spec = OGIP_Spectrum(path; T)
+    spec = OGIP_Events(path; T)
     rm = OGIP_RMF(rm_path; T)
     arf = OGIP_ARF(arf_path; T)
     meta = XmmNewtonMeta(D(), path, rm_path, arf_path)

--- a/src/spectral-datasets/missions/xmm-newton-mission.jl
+++ b/src/spectral-datasets/missions/xmm-newton-mission.jl
@@ -24,7 +24,7 @@ function SpectralDataset(
     arf_path;
     T::Type = Float64,
 ) where {D}
-    spec = OGIP_Events(path; T)
+    spec = OGIP_GroupedEvents(path; T)
     rm = OGIP_RMF(rm_path; T)
     arf = OGIP_ARF(arf_path; T)
     meta = XmmNewtonMeta(D(), path, rm_path, arf_path)

--- a/src/spectral-datasets/ogip-io.jl
+++ b/src/spectral-datasets/ogip-io.jl
@@ -1,29 +1,47 @@
-struct OGIP_Spectrum{T}
+struct OGIP_EventsHeader{T}
     exposure_time::T
     background_scale::T
     area_scale::T
     systematic_error::T
     poisson_error::Bool
     units::Symbol
+    # metadata
+    telescope::String
+    instrument::String
+end
 
+struct OGIP_Events{T}
+    header::OGIP_EventsHeader{T}
     channels::Vector{Int}
     quality::Vector{Int}
     grouping::Vector{Int}
     # may be counts or rate depending
     values::Vector{T}
     stat_error::Vector{T}
-
-    # metadata
-    telescope::String
-    instrument::String
 end
 
-function OGIP_Spectrum(fits::FITS, ::Type{T})::OGIP_Spectrum{T} where {T}
+function _read_exposure_time(header)
+    if get(header, "EXPOSURE", 0.0) != 0.0
+        return header["EXPOSURE"]
+    end
+    if get(header, "TELAPSE", 0.0) != 0.0
+        return header["TELAPSE"]
+    end
+    # maybe time stops given
+    if (get(header, "TSTART", 0.0) != 0.0) && (get(header, "TSTOP", 0.0) != 0.0)
+        return header["TSTOP"] - header["TSTART"]
+    end
+    @warn("Cannot find or infer exposure time.")
+    0.0
+end
+
+function OGIP_Events(fits::FITS, ::Type{T})::OGIP_Events{T} where {T}
     header = read_header(fits[2])
-    is_poisson = header["POISSERR"]
+    # if not set, assume not poisson errors
+    is_poisson = get(header, "POISSERR", false)
     instrument = header["INSTRUME"]
     telescope = header["TELESCOP"]
-    exposure_time = T(header["EXPOSURE"])
+    exposure_time = T(_read_exposure_time(header))
     background_scale = T(header["BACKSCAL"])
     area_scale = T(header["AREASCAL"])
     sys_error = T(header["SYS_ERR"])
@@ -50,21 +68,17 @@ function OGIP_Spectrum(fits::FITS, ::Type{T})::OGIP_Spectrum{T} where {T}
         T[0 for _ in values]
     end
 
-    OGIP_Spectrum(
+    ogip_header = OGIP_EventsHeader(
         exposure_time,
         background_scale,
         area_scale,
         sys_error,
         is_poisson,
         units,
-        channels,
-        quality,
-        grouping,
-        values,
-        stat_errors,
         telescope,
         instrument,
     )
+    OGIP_Events(ogip_header, channels, quality, grouping, values, stat_errors)
 end
 
 struct OGIP_ARF{T}
@@ -167,9 +181,9 @@ OGIP_RMF(fits::FITS, T::Type) =
     OGIP_RMF(OGIP_RMF_Matrix(fits, T), OGIP_RMF_Channels(fits, T))
 
 # utility constructors for path specs
-function OGIP_Spectrum(path::String; T = Float64)
+function OGIP_Events(path::String; T = Float64)
     fits = FITS(path)
-    spec = OGIP_Spectrum(fits, T)
+    spec = OGIP_Events(fits, T)
     close(fits)
     spec
 end

--- a/src/spectral-datasets/ogip-io.jl
+++ b/src/spectral-datasets/ogip-io.jl
@@ -1,4 +1,4 @@
-struct OGIP_EventsHeader{T}
+struct OGIP_GroupedEventsHeader{T}
     exposure_time::T
     background_scale::T
     area_scale::T
@@ -10,8 +10,8 @@ struct OGIP_EventsHeader{T}
     instrument::String
 end
 
-struct OGIP_Events{T}
-    header::OGIP_EventsHeader{T}
+struct OGIP_GroupedEvents{T}
+    header::OGIP_GroupedEventsHeader{T}
     channels::Vector{Int}
     quality::Vector{Int}
     grouping::Vector{Int}
@@ -35,7 +35,7 @@ function _read_exposure_time(header)
     0.0
 end
 
-function OGIP_Events(fits::FITS, ::Type{T})::OGIP_Events{T} where {T}
+function OGIP_GroupedEvents(fits::FITS, ::Type{T})::OGIP_GroupedEvents{T} where {T}
     header = read_header(fits[2])
     # if not set, assume not poisson errors
     is_poisson = get(header, "POISSERR", false)
@@ -68,7 +68,7 @@ function OGIP_Events(fits::FITS, ::Type{T})::OGIP_Events{T} where {T}
         T[0 for _ in values]
     end
 
-    ogip_header = OGIP_EventsHeader(
+    ogip_header = OGIP_GroupedEventsHeader(
         exposure_time,
         background_scale,
         area_scale,
@@ -78,13 +78,13 @@ function OGIP_Events(fits::FITS, ::Type{T})::OGIP_Events{T} where {T}
         telescope,
         instrument,
     )
-    OGIP_Events(ogip_header, channels, quality, grouping, values, stat_errors)
+    OGIP_GroupedEvents(ogip_header, channels, quality, grouping, values, stat_errors)
 end
 
 struct OGIP_ARF{T}
     spec_response::Vector{T}
-    energy_bins_low::Vector{T}
-    energy_bins_high::Vector{T}
+    bins_low::Vector{T}
+    bins_high::Vector{T}
 end
 
 function OGIP_ARF(fits::FITS, ::Type{T})::OGIP_ARF{T} where {T}
@@ -97,8 +97,8 @@ end
 
 struct OGIP_RMF_Channels{T}
     channels::Vector{Int}
-    energy_bins_low::Vector{T}
-    energy_bins_high::Vector{T}
+    bins_low::Vector{T}
+    bins_high::Vector{T}
 end
 
 function OGIP_RMF_Channels(fits::FITS, ::Type{T})::OGIP_RMF_Channels{T} where {T}
@@ -112,8 +112,8 @@ end
 struct OGIP_RMF_Matrix{T,M}
     Fchan::Matrix{Int}
     Nchan::Matrix{Int}
-    energy_bins_low::Vector{T}
-    energy_bins_high::Vector{T}
+    bins_low::Vector{T}
+    bins_high::Vector{T}
     matrix_rows::M
     first_channel::Int
     number_of_channels::Int
@@ -181,9 +181,9 @@ OGIP_RMF(fits::FITS, T::Type) =
     OGIP_RMF(OGIP_RMF_Matrix(fits, T), OGIP_RMF_Channels(fits, T))
 
 # utility constructors for path specs
-function OGIP_Events(path::String; T = Float64)
+function OGIP_GroupedEvents(path::String; T = Float64)
     fits = FITS(path)
-    spec = OGIP_Events(fits, T)
+    spec = OGIP_GroupedEvents(fits, T)
     close(fits)
     spec
 end

--- a/src/spectral-datasets/response-matrix.jl
+++ b/src/spectral-datasets/response-matrix.jl
@@ -11,10 +11,10 @@ function ResponseMatrix(rmf::OGIP_RMF{T}) where {T}
     ResponseMatrix(
         matrix,
         chan.channels,
-        chan.energy_bins_low,
-        chan.energy_bins_high,
-        rm.energy_bins_low,
-        rm.energy_bins_high,
+        chan.bins_low,
+        chan.bins_high,
+        rm.bins_low,
+        rm.bins_high,
     )
 end
 
@@ -23,7 +23,7 @@ Base.:*(rm::ResponseMatrix, flux) = fold_response(flux, rm)
 @fastmath fold_response(flux, rm::ResponseMatrix) = rm.matrix * flux
 
 function fold_response(flux, energy, rm::ResponseMatrix)
-    if length(rm.energy_bins_low) != length(energy) - 1
+    if length(rm.bins_low) != length(energy) - 1
         out_flux = rebin_flux(flux, energy, rm)
         fold_response(out_flux, rm)
     else
@@ -35,22 +35,22 @@ function group_response_channels(rm::ResponseMatrix{T}, grouping) where {T}
     indices = grouping_to_indices(grouping)
     N = length(indices) - 1
     R = spzeros(T, (N, size(rm.matrix, 2)))
-    energy_low = zeros(T, N)
-    energy_high = zeros(T, N)
+    bin_low = zeros(T, N)
+    bin_high = zeros(T, N)
 
     grouping_indices_callback(indices) do (i, index1, index2)
         @views R[i, :] .= vec(sum(rm.matrix[index1:index2, :], dims = 1))
-        energy_low[i] = rm.channel_energy_bins_low[index1]
-        energy_high[i] = rm.channel_energy_bins_high[index1]
+        bin_low[i] = rm.channel_bins_low[index1]
+        bin_high[i] = rm.channel_bins_high[index1]
     end
 
     ResponseMatrix(
         R,
         collect(1:N),
-        energy_low,
-        energy_high,
-        rm.energy_bins_low,
-        rm.energy_bins_high,
+        bin_low,
+        bin_high,
+        rm.bins_low,
+        rm.bins_high,
     )
 end
 


### PR DESCRIPTION
Removing some of the association that the bins are always energy (allow for frequency fits too without that weird double think).

Also cleaned up the OGIP parsing a little by separating headers, in preparation for a direct source/background parser. Renamed to `GroupedEvents` for now. Need method for calculating area and background scaling factor in the package directly, since this is currently done by `grppha`.

