### PR TITLE
ccall: allow callsite specification

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpectralFitting"
 uuid = "f2c56810-742e-4b72-8bf4-27af3bb81a12"
 authors = ["Fergus Baker <fergusbkr@gmail.com>"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"


### PR DESCRIPTION
Previously all models had to be defined as symbols in the `libXSFunctions` shared library. Now, the `@xspecmodel` macro may accept a tuple in place of a symbol, where the second argument to the tupple specifies the callsite of the function.