### PR TITLE
Binned datasets with no response matrices

### DIFF
--- a/src/SpectralFitting.jl
+++ b/src/SpectralFitting.jl
@@ -53,6 +53,7 @@ include("datasets/response-matrix.jl")
 include("datasets/binning-utilities.jl")
 include("datasets/missions/abstract-mission.jl")
 include("datasets/simple-dataset.jl")
+include("datasets/binned-dataset.jl")
 
 include("model-data-io.jl")
 

--- a/src/datasets/binned-dataset.jl
+++ b/src/datasets/binned-dataset.jl
@@ -1,0 +1,41 @@
+# simple binned dataset with no mission, background, or responses
+# simple_spectrum just contains counts
+
+function SpectralDataset(bins_low, bins_high, simple_spectrum, simple_errors)
+    println("Creating simple spectral dataset")
+    
+    println("Creating spectrum")
+    spectrum = Spectrum(
+        collect(1:length(simple_spectrum)), # channels
+        fill(1, size(simple_spectrum)), # quality
+        fill(1, size(simple_spectrum)), # grouping
+        simple_spectrum, # values
+        "counts", # unit_string
+        1.0, # exposure time
+        1.0, # background scale
+        1.0, # area scale
+        SpectralFitting.ErrorStatistics.Gaussian, # assume Gaussian errors
+        simple_errors, # errors
+        0.0, # systematic error
+        "no telescope", # telescope
+        "no instrument", # instrument
+    )
+    println("Spectrum values are")
+    println(spectrum.values)
+
+    println("Creating basic metadata")
+    meta = BasicMetadata("no path", "no path", "no telescope", "no instrument")
+
+    println("Creating dataset")
+    SpectralDataset(
+        SpectralUnits.u"counts",
+        meta,
+        bins_low,
+        bins_high,
+        spectrum, # <-- should be Spectrum type
+        missing, # no background
+        missing, # no response
+        missing, # no ancillary response
+        BitVector(fill(true, size(spectrum.values)))
+     )
+end

--- a/src/datasets/binning-utilities.jl
+++ b/src/datasets/binning-utilities.jl
@@ -55,7 +55,7 @@ function downsample_rebin(input, current_bins, target_bins_high)
     output
 end
 
-function domain_vector(response::ResponseMatrix{T}) where {T}
+function (response::ResponseMatrix{T}) where {T}
     domain_vector(response, T)
 end
 


### PR DESCRIPTION
N.B. This is a *draft* pull request (PR) and should not be merged with the main branch. It does not work!

The purpose of this PR is to illustrate some of the issues I've run into when trying to fit multi-wavelength datasets (ultimately we want to do this with X-ray data too). Rather than upload test code to the repository, here is what I've been trying to do. The first code snippet reads in the datafile (also reproduced below), sets up the energy bins and flux density bins, then constructs the fitting problem and fits the dataset.

I've made various minor changes to `SpectralFitting` to remove the need to have response matrices or ancillary response matrices.

I switched the grouping reporting logic to
```julia
is_grouped = all(==(1), data.spectrum.grouping) ? "no" : "yes"
```

One problem I've run into is that `invokemodel` assumes that the energy bins are contiguous, which is not the case here. In fact, this may not be the case for simple X-ray datasets if, e.g., a problematic energy range is excluded such as around a mirror edge in the response. Maybe a workaround would be separate datasets for each observation, but as just mentioned the non-contiguous binning might be a problem elsewhere in any case.

```julia
# fitting the broad-band spectral energy distribution of SWIFT J0909
# makes use of SpectralFitting.jl to fit multi-wavelength datasets simultaneously
# documentation at https://fjebaker.github.io/SpectralFitting.jl/dev/
# requires adding package https://github.com/astro-group-bristol/LibXSPEC_jll.jl

using Revise
using Logging
using SpectralFitting
using CSV
using Plots

# read in data values
file = CSV.File(@__DIR__() * "/../data/digitized_data.csv"; comment="#")

# create a binned dataset which is more compatible with XSPEC
# will need to change units to keV and counts in bin
# see unit conversion tables in Zombeck, Handbook of Space Astronomy and Astrophysics
# ν; Hz -> keV; bin width ±5% of bin centre
# νF_ν; erg/cm^2/s -> photons/cm^2/s in bin; ±10% errors

E = 4.14E-18 * file.nu[1:8]
E_low = 4.14E-18 * file.nu[1:8] .* 0.95
E_high = 4.14E-18 * file.nu[1:8] .* 1.05
ΔE = E_high .- E_low
νF_ν = file.nuFnu[1:8] .* 1.0E-15
F_ν = νF_ν ./ file.nu[1:8]
f_E = 1.51E26 .* F_ν ./ E
int_f_E = ΔE .* f_E
int_f_E_err = 0.1 * int_f_E

SEDdata = SpectralDataset(E_low, E_high, int_f_E, int_f_E_err)

# plot E and int_f_E on a log log scale
plot(E, int_f_E ./ ΔE, xaxis=:log, yaxis=:log, xlabel="E (keV)", ylabel="f_E (photons/cm^2/s/keV)", label="data", seriestype=:scatter, markershape=:cross)

# define the model
model = XS_BlackBody(
    T = FitParam(1.0E-3; lower_limit=1.0E-5, upper_limit=1.0, error=1.0E-6),
    K = FitParam(1.0E-15; lower_limit=0.0, upper_limit=1.0E-10, error=1.0E-16)
)

# define the fitting problem
prob = FittingProblem(model, SEDdata)

# fit using Levenberg Marquadt
res = fit(prob, LevenbergMarquadt(), autodiff = :finite)

# plot data
plot(SEDdata, xlim=[1e8, 1e24], ylim=[1e-2,1e5])

# get the model flux (note there is not response to be folded at the moment)
# ah, the problem here is that the "energy bins" are *not* contiguous so the flux array has n-1 elements and ΔE has n elements
flux = invokemodel(E, model, res.u)
@. flux = flux / ΔE
```

and the CSV data file is as follows

```
nu nuFnu
# Data taken from proposal using WebPlotDigitizer
# FIRST dataset
1390664941.8702261 2.033010093746376
# PMN dataset
4623401790.223448 6.486575895581095
# CLASSCAT dataset
8430070411.415518 12.388629239937776
# WISE dataset
13582894496204.066 344.2085908989842
25657076028963.61 184.29089363957826
62063873158783.55 61.75863298586859
88367294804333.78 82.5404185268019
# UVOT u
818546730706905.5 77.19637359248672
# XRT
994128341530770300 176.2479324448388
4542437939833856500 982.308861816593
# BAT
30614946429429970000 5007.4013617129785
74056846922624420000 5724.68952535363
# LAT upper limit
1.0059063384715383e+22 5354.046892271284
1.708978397005311e+22 3065.0256162437545
3.3442341329406997e+22 1918.4290247450026
6.279917873016559e+23 525.9327708859672
1.877834392980856e+24 439.95762880990907
3.3050770286651294e+24 537.799203941809
5.817091329374369e+24 1004.4723454292821
```