### PR TITLE
Add data_mask to InjectiveData

### DIFF
--- a/src/datasets/injectivedata.jl
+++ b/src/datasets/injectivedata.jl
@@ -31,7 +31,7 @@ function make_model_domain(::ContiguouslyBinned, dataset::InjectiveData)
 end
 make_objective(::ContiguouslyBinned, dataset::InjectiveData) = dataset.codomain[dataset.data_mask]
 
-make_model_domain(::OneToOne, dataset::InjectiveData) = dataset.domain[data_mask]
+make_model_domain(::OneToOne, dataset::InjectiveData) = dataset.domain[dataset.data_mask]
 make_objective(::OneToOne, dataset::InjectiveData) = dataset.codomain[data_mask]
 
 function make_objective_variance(

--- a/src/datasets/injectivedata.jl
+++ b/src/datasets/injectivedata.jl
@@ -29,7 +29,7 @@ function make_model_domain(::ContiguouslyBinned, dataset::InjectiveData)
     push!(domain, domain[end] + Δ)
     domain
 end
-make_objective(::ContiguouslyBinned, dataset::InjectiveData) = dataset.codomain[data_mask]
+make_objective(::ContiguouslyBinned, dataset::InjectiveData) = dataset.codomain[dataset.data_mask]
 
 make_model_domain(::OneToOne, dataset::InjectiveData) = dataset.domain[data_mask]
 make_objective(::OneToOne, dataset::InjectiveData) = dataset.codomain[data_mask]

--- a/src/datasets/injectivedata.jl
+++ b/src/datasets/injectivedata.jl
@@ -38,7 +38,7 @@ function make_objective_variance(
     ::AbstractDataLayout,
     dataset::InjectiveData{V},
 )::V where {V}
-    if !isnothing(dataset.domain_variance)
+    if !isnothing(dataset.codomain_variance)
         dataset.codomain_variance[dataset.data_mask]
     else
         # todo: i dunno just something

--- a/src/datasets/injectivedata.jl
+++ b/src/datasets/injectivedata.jl
@@ -32,7 +32,7 @@ end
 make_objective(::ContiguouslyBinned, dataset::InjectiveData) = dataset.codomain[dataset.data_mask]
 
 make_model_domain(::OneToOne, dataset::InjectiveData) = dataset.domain[dataset.data_mask]
-make_objective(::OneToOne, dataset::InjectiveData) = dataset.codomain[data_mask]
+make_objective(::OneToOne, dataset::InjectiveData) = dataset.codomain[dataset.data_mask]
 
 function make_objective_variance(
     ::AbstractDataLayout,
@@ -46,7 +46,15 @@ function make_objective_variance(
     end
 end
 
-objective_transformer(::AbstractDataLayout, dataset::InjectiveData) = _DEFAULT_TRANSFORMER()
+function objective_transformer(::AbstractDataLayout, dataset::InjectiveData)
+    function _transformer!!(domain, objective)
+        @views objective[dataset.data_mask]
+    end
+    function _transformer!!(output, domain, objective)
+        @. output = objective[dataset.data_mask]
+    end
+    _transformer!!
+end
 
 make_label(dataset::InjectiveData) = dataset.name
 

--- a/src/datasets/injectivedata.jl
+++ b/src/datasets/injectivedata.jl
@@ -31,7 +31,7 @@ function make_model_domain(::ContiguouslyBinned, dataset::InjectiveData)
 end
 make_objective(::ContiguouslyBinned, dataset::InjectiveData) = dataset.codomain[dataset.data_mask]
 
-make_model_domain(::OneToOne, dataset::InjectiveData) = dataset.domain[dataset.data_mask]
+make_model_domain(::OneToOne, dataset::InjectiveData) = dataset.domain
 make_objective(::OneToOne, dataset::InjectiveData) = dataset.codomain[dataset.data_mask]
 
 function make_objective_variance(

--- a/test/fitting/test-fit-simple-dataset.jl
+++ b/test/fitting/test-fit-simple-dataset.jl
@@ -47,11 +47,11 @@ result = fit(prob, LevenbergMarquadt())
 
 # fitting a contiguously binned dataset with some masked bins
 x = 10 .^ collect(range(-1, 2, 10))
-y = energy_grid .^ -2.0
+y = x .^ -2.0
 y_err = 0.1 .* int_f_E
 # introduce some bogus data points to ignore
 int_f_E[2:5] .= 2.0
-data = InjectiveData(energy_grid, int_f_E, codomain_variance=int_f_E_var)
+data = InjectiveData(x, int_f_E, codomain_variance=int_f_E_var)
 # mask out the bogus data points
 data.data_mask[2:5] .= false
 model = XS_PowerLaw(K=FitParam(1.0E-5), a=FitParam(2.0))

--- a/test/fitting/test-fit-simple-dataset.jl
+++ b/test/fitting/test-fit-simple-dataset.jl
@@ -48,10 +48,10 @@ result = fit(prob, LevenbergMarquadt())
 # fitting a contiguously binned dataset with some masked bins
 x = 10 .^ collect(range(-1, 2, 10))
 y = x .^ -2.0
-y_err = 0.1 .* int_f_E
+y_err = 0.1 .* y
 # introduce some bogus data points to ignore
-int_f_E[2:5] .= 2.0
-data = InjectiveData(x, int_f_E, codomain_variance=int_f_E_var)
+y[2:5] .= 2.0
+data = InjectiveData(x, y, codomain_variance=y_err)
 # mask out the bogus data points
 data.data_mask[2:5] .= false
 model = XS_PowerLaw(K=FitParam(1.0E-5), a=FitParam(2.0))

--- a/test/fitting/test-fit-simple-dataset.jl
+++ b/test/fitting/test-fit-simple-dataset.jl
@@ -44,3 +44,20 @@ prob = FittingProblem(model => data)
 
 result = fit(prob, LevenbergMarquadt())
 @test result.u[2] ≈ 6.1 atol = 0.1
+
+# fitting a contiguously binned dataset with some masked bins
+x = 10 .^ collect(range(-1, 2, 10))
+y = energy_grid .^ -2.0
+y_err = 0.1 .* int_f_E
+# introduce some bogus data points to ignore
+int_f_E[2:5] .= 2.0
+data = InjectiveData(energy_grid, int_f_E, codomain_variance=int_f_E_var)
+# mask out the bogus data points
+data.data_mask[2:5] .= false
+model = XS_PowerLaw(K=FitParam(1.0E-5), a=FitParam(2.0))
+prob = FittingProblem(model => data)
+@test SpectralFitting.common_support(model, data) isa SpectralFitting.ContiguouslyBinned
+result = fit(prob, LevenbergMarquadt())
+@test result.u[1] ≈ 2.55 atol = 0.01
+@test result.u[2] ≈ 3.0 atol = 0.05
+# note best fit photon index, u[2] should be 3 not 2 becuase y contains bin integrated values not the density


### PR DESCRIPTION
This pull request adds a new field `data_mask` to the `InjectiveData` struct. The `data_mask` is a `BitVector` that allows for masking specific data points in the `codomain` array. This feature is useful for filtering out certain data points during analysis or modeling. The `data_mask` is initialized with all `true` values by default.