### PR TITLE
Temporary fix to `prettyfloat` to work around `InexactError`

### DIFF
--- a/src/print-utilities.jl
+++ b/src/print-utilities.jl
@@ -1,11 +1,23 @@
-
 function prettyfloat(f)
     if f == 0
         "0.0"
     elseif f == Inf
         "Inf"
-    elseif (f ≥ 1) && (f - trunc(Int, f) < 1e-8)
-        Printf.@sprintf("%.1f", f)
+    elseif (f ≥ 1)
+        #  ignore "InexactError" if, e.g., f is very large
+        remainder = 1.0
+        try
+            remainder = f - trunc(Int, f)
+        catch e
+            if !isa(e, InexactError)
+                rethrow(e)
+            end
+        end
+        if remainder < 1e-8
+            Printf.@sprintf("%.1f", f)
+        else
+            Printf.@sprintf("%#.5g", f)
+        end
     else
         Printf.@sprintf("%#.5g", f)
     end

--- a/src/print-utilities.jl
+++ b/src/print-utilities.jl
@@ -3,21 +3,8 @@ function prettyfloat(f)
         "0.0"
     elseif f == Inf
         "Inf"
-    elseif (f ≥ 1)
-        #  ignore "InexactError" if, e.g., f is very large
-        remainder = 1.0
-        try
-            remainder = f - trunc(Int, f)
-        catch e
-            if !isa(e, InexactError)
-                rethrow(e)
-            end
-        end
-        if remainder < 1e-8
-            Printf.@sprintf("%.1f", f)
-        else
-            Printf.@sprintf("%#.5g", f)
-        end
+    elseif ((f ≥ 1) && (f < 1e5) && (f - trunc(Int, f)  < 1e-5))
+        Printf.@sprintf("%.1f", f)
     else
         Printf.@sprintf("%#.5g", f)
     end


### PR DESCRIPTION
Perhaps a bit clunky but a quick, simple fix so `prettyfloat` function works around `InexactError` if it crops up. I couldn't quickly think of a way of doing this more compactly without adding $\sim 9$ lines of code!

We ran into the `InexactError` because we were using frequency units rather than keV so some numbers became extremely large (e.g., 6.579332246575656e24).