### PR TITLE
Fixing bind mapping with multiple models

### DIFF
--- a/src/fitting/binding.jl
+++ b/src/fitting/binding.jl
@@ -1,40 +1,30 @@
 _sort_binding!(binding) = sort!(binding, by = i -> i[1])
 
 function _construct_bound_mapping(bindings, parameter_count)
-    println("Bindings are ", bindings)
-    println("Parameter count is ", parameter_count, " with length ", length(parameter_count))
     remove = Int[]
 
     parameter_mapping = map((1:length(parameter_count)...,)) do i
         # indices of the full parameter array for the ith model
         collect(range(_get_range(parameter_count, i)...))
     end
-    println("Initial parameter mapping is ", parameter_mapping)
 
     for binding in bindings
-        println("  Looking at binding ", binding)
         # the model we use as a reference to bind *to*
         reference = binding[1]
-        println("  Reference to bind to is ", reference)
         for b in @views binding[2:end]
-            println("    Now considering binding ", b, " which has elements ", b[1], " and ", b[2])
             # get the number of the parameter that we are binding
             parameter_number = parameter_mapping[b[1]][b[2]]
             parameter_mapping[b[1]][b[2]] = reference[2]
-            println("    Reference[2] is ", reference[2])
-            println("    Parameter mapping is ", parameter_mapping)
 
             # mark for removal: find the parameter index in the global array
             N = sum(length(parameter_mapping[q]) for q = 1:b[1]-1)
             index = N + b[2]
             push!(remove, index)
-            println("    Remove updated to be ", remove, " having added ", index, " with value ", parameter_number)
 
             # need to now shuffle all the indices greater than this one down by 1
             for k = b[2]+1:length(parameter_mapping[b[1]])
                 if (parameter_mapping[b[1]][k] > parameter_number)
                     parameter_mapping[b[1]][k] -= 1
-                    println("      Changed parameter_mapping[", b[1], "][", k, "] to ", parameter_mapping[b[1]][k])
                 end
             end
             # and for subsequent models
@@ -42,11 +32,9 @@ function _construct_bound_mapping(bindings, parameter_count)
                 for k = 1:length(parameter_mapping[j])
                     if parameter_mapping[j][k] > parameter_number
                         parameter_mapping[j][k] -= 1
-                        println("      Also changed mapping[", j, "][", k, "] to ", parameter_mapping[j][k])
                     end
                 end
             end
-            println("    Parameter mapping is ", parameter_mapping)
         end
     end
 

--- a/src/fitting/binding.jl
+++ b/src/fitting/binding.jl
@@ -1,32 +1,52 @@
 _sort_binding!(binding) = sort!(binding, by = i -> i[1])
 
 function _construct_bound_mapping(bindings, parameter_count)
+    println("Bindings are ", bindings)
+    println("Parameter count is ", parameter_count, " with length ", length(parameter_count))
     remove = Int[]
 
     parameter_mapping = map((1:length(parameter_count)...,)) do i
         # indices of the full parameter array for the ith model
         collect(range(_get_range(parameter_count, i)...))
     end
+    println("Initial parameter mapping is ", parameter_mapping)
 
     for binding in bindings
+        println("  Looking at binding ", binding)
         # the model we use as a reference to bind *to*
         reference = binding[1]
+        println("  Reference to bind to is ", reference)
         for b in @views binding[2:end]
+            println("    Now considering binding ", b, " which has elements ", b[1], " and ", b[2])
+            # get the number of the parameter that we are binding
+            parameter_number = parameter_mapping[b[1]][b[2]]
             parameter_mapping[b[1]][b[2]] = reference[2]
+            println("    Reference[2] is ", reference[2])
+            println("    Parameter mapping is ", parameter_mapping)
 
             # mark for removal: find the parameter index in the global array
             N = sum(length(parameter_mapping[q]) for q = 1:b[1]-1)
             index = N + b[2]
             push!(remove, index)
+            println("    Remove updated to be ", remove, " having added ", index, " with value ", parameter_number)
 
             # need to now shuffle all the indices greater than this one down by 1
             for k = b[2]+1:length(parameter_mapping[b[1]])
-                parameter_mapping[b[1]][k] -= 1
+                if (parameter_mapping[b[1]][k] > parameter_number)
+                    parameter_mapping[b[1]][k] -= 1
+                    println("      Changed parameter_mapping[", b[1], "][", k, "] to ", parameter_mapping[b[1]][k])
+                end
             end
             # and for subsequent models
             for j = b[1]+1:length(parameter_count)
-                parameter_mapping[j] .-= 1
+                for k = 1:length(parameter_mapping[j])
+                    if parameter_mapping[j][k] > parameter_number
+                        parameter_mapping[j][k] -= 1
+                        println("      Also changed mapping[", j, "][", k, "] to ", parameter_mapping[j][k])
+                    end
+                end
             end
+            println("    Parameter mapping is ", parameter_mapping)
         end
     end
 

--- a/test/fitting/test-binding.jl
+++ b/test/fitting/test-binding.jl
@@ -54,3 +54,9 @@ values = trunc.(Int, get_value.(parameters))
 
 model1 = PowerLaw()
 model2 = PowerLaw() + PowerLaw()
+
+# test multiple bindings with multiple models and multiple datasets
+prob = FittingProblem(model1 => dummy_data1, model1 => dummy_data1, model1 => dummy_data1)
+bind!(prob, :K, :a)
+_, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
+@test mapping == ([1, 2], [1, 2], [1, 2])

--- a/test/fitting/test-binding.jl
+++ b/test/fitting/test-binding.jl
@@ -60,3 +60,20 @@ prob = FittingProblem(model1 => dummy_data1, model1 => dummy_data1, model1 => du
 bind!(prob, :K, :a)
 _, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
 @test mapping == ([1, 2], [1, 2], [1, 2])
+
+# 3 models, 1 bound parameter
+prob = FittingProblem(model1 => dummy_data1, model1 => dummy_data1, model1 => dummy_data1)
+bind!(prob, :a)
+_, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
+@test mapping == ([1, 2], [3, 2], [4, 2])
+
+# 3 models (2 the same, 1 different), bind one parameter between the two
+prob = FittingProblem(model1 => dummy_data1, model2 => dummy_data1, model1 => dummy_data1)
+bind!(prob, 1 => :a, 2 => :a_2, 3 => :a)
+_, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
+@test mapping == ([1, 2], [3, 4, 5, 2], [6, 2])
+
+# 2 models, both different, bind a parameter that is only in one model (check it does no-ops okay)
+# prob = FittingProblem(model1 => dummy_data1, model2 => dummy_data1)
+# bind!(prob, :K)
+# note that this does not work at present because `_get_index_of_symbol` throws an error if the symbol is not found


### PR DESCRIPTION
This PR addresses #89 regarding a problem with `bind` if there are multiple models and datasets.

Once a parameter has been bound to another parameter it must relinquish the parameter number it had before being bound. This means that there is now a gap in the contiguous list of parameter numbers. Larger parameter numbers then need to be shuffled down by one to fill this gap, resulting in a contiguous list of parameters. The problem was that all later parameters in the lit were being decremented by 1 regardless of whether they were larger or not.

A test case has been added to check that `bind` works as anticipated for multiple models and datasets. Further tests could usefully be added.

Finally, there are lots of debugging `println` statements that can be removed once we're satisfied the code is working properly.