### PR TITLE
fix: bind parameters in models with frozen parameters

### DIFF
--- a/src/fitting/binding.jl
+++ b/src/fitting/binding.jl
@@ -44,10 +44,17 @@ function _construct_bound_mapping(bindings, parameter_count)
 end
 
 function _get_index_of_symbol(model::AbstractSpectralModel, symbol)::Int
-    symbols = keys(parameter_named_tuple(model))
+    pnt = parameter_named_tuple(model)
+    symbols = keys(pnt)
     i = findfirst(==(symbol), symbols)
     if isnothing(i)
         error("Could not match symbol $symbol !")
+    end
+    # don't count frozen parameters if they are prior to the parameter of interest
+    for s = 1:i
+        if isfrozen(pnt[s])
+            i -= 1
+        end
     end
     i
 end

--- a/test/fitting/test-binding.jl
+++ b/test/fitting/test-binding.jl
@@ -80,6 +80,7 @@ _, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
 # note that this does not work at present because `_get_index_of_symbol` throws an error if the symbol is not found
 
 # 3 models, 1 frozen parameter (that needs to be skipped), 1 bound parameter
+model1 = PowerLaw() + PowerLaw()
 prob = FittingProblem(model1 => dummy_data1, model1 => dummy_data1, model1 => dummy_data1)
 model1.K_1.frozen = true
 bind!(prob, :a_1)

--- a/test/fitting/test-binding.jl
+++ b/test/fitting/test-binding.jl
@@ -78,3 +78,20 @@ _, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
 # prob = FittingProblem(model1 => dummy_data1, model2 => dummy_data1)
 # bind!(prob, :K)
 # note that this does not work at present because `_get_index_of_symbol` throws an error if the symbol is not found
+
+# 3 models, 1 frozen parameter (that needs to be skipped), 1 bound parameter
+prob = FittingProblem(model1 => dummy_data1, model1 => dummy_data1, model1 => dummy_data1)
+model1.K_1.frozen = true
+bind!(prob, :a_1)
+bind!(prob, :a_2)
+_, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
+@test mapping == ([1, 2, 3], [1, 4, 3], [1, 5, 3])
+
+# 3 models, 1 frozen parameter (that doesn't need to be skipped), 1 bound parameter
+prob = FittingProblem(model1 => dummy_data1, model1 => dummy_data1, model1 => dummy_data1)
+model1.K_1.frozen = false
+model1.a_2.frozen = true
+bind!(prob, :K_1)
+bind!(prob, :a_1)
+_, mapping = SpectralFitting._build_parameter_mapping(prob.model, prob.bindings)
+@test mapping == ([1, 2, 3], [1, 2, 4], [1, 2, 5])


### PR DESCRIPTION
When binding parameters we should only be considering free parameters in the model, not all parameters. Updated _get_index_of_symbol in binding.jl to skip frozen parameters.

Added a couple of test cases to check this works. Could probably add more tests.