### PR TITLE
fixed the issues with reversed data when interpolating

### DIFF
--- a/src/meta-models/table-models.jl
+++ b/src/meta-models/table-models.jl
@@ -117,7 +117,7 @@ function interpolate_table!(
         tmi.interpolator,
         tmi.data.params,
         tmi.data.grids,
-        convert.(T, parameters),
+        reverse(convert.(T, parameters)),
     )
     v.values
 end
@@ -152,6 +152,7 @@ function TableModelData(::Val{N}, path::String; T::Type = Float64) where {N}
     parameter_axes = map(1:size(parameter_meshgrid, 1)) do i
         unique!(parameter_meshgrid[i, :])
     end
+    reverse!(parameter_axes)
 
     _data::Matrix{T} = convert.(T, read(f[4], "INTPSPEC"))
     _expected_size = reduce(*, length(i) for i in parameter_axes)
@@ -161,9 +162,6 @@ function TableModelData(::Val{N}, path::String; T::Type = Float64) where {N}
     _grid = map(1:size(_data, 2)) do i
         TableGridData(_data[:, i])
     end
-
-    # order of the table is the reverse of how we interpolate
-    reverse!(_grid)
 
     param_tuple = ((parameter_axes[i] for i = 1:N)...,)
     grid = reshape(_grid, length.(param_tuple))


### PR DESCRIPTION
Fixing the issue of reversed data in the interpolation of table models. The fix involved reversing the order of the parameter_axes and then reversing the order of the variables in the table invocation. This is not the most elegant way of doing this but it works. 

Varying logxi before the fix 
![Screenshot 2025-03-21 at 15 05 06](https://github.com/user-attachments/assets/64b8d2cc-4ba4-4373-b410-6275230249f9)
Varying logxi after the fix 
![Screenshot 2025-03-21 at 15 04 35](https://github.com/user-attachments/assets/6af6ba99-3662-46f9-8193-e5331a02efb2)