### PR TITLE
feat: add ParameterPatch

### DIFF
--- a/src/SpectralFitting.jl
+++ b/src/SpectralFitting.jl
@@ -55,6 +55,7 @@ include("meta-models/table-models.jl")
 include("meta-models/surrogate-models.jl")
 include("meta-models/caching.jl")
 include("meta-models/functions.jl")
+include("meta-models/parameter-patch.jl")
 
 include("datasets/ogip.jl")
 include("datasets/datasets.jl")

--- a/src/meta-models/parameter-patch.jl
+++ b/src/meta-models/parameter-patch.jl
@@ -1,0 +1,152 @@
+"""
+    ParameterPatchView{V<:AbstractVector}
+
+Part of [`ParameterPatch`](@ref).
+
+Used to create a view on a set of parameters that can be manipulated in an
+intuitive way. Defines property setting / getting methods so that the parameters
+associated with a particular model can be reached
+```julia
+p = ParameterPatchView(...)
+p.a1 # returns a ModelPatchView
+```
+
+The possible properties that can be access are defined in a symbol vector.
+
+Every "model" accessed this way will return a view on the parameters via
+[`ModelPatchView`](@ref).
+"""
+struct ParameterPatchView{V<:AbstractVector}
+    _values::V
+    _symbols::Vector{Pair{Symbol,Symbol}}
+    function ParameterPatchView(values::V, symbols) where {V<:AbstractVector}
+        @assert size(values) == size(symbols)
+        new{V}(values, symbols)
+    end
+end
+
+"""
+    ModelPatchView{P<:ParameterPatchView}
+
+Similar to [`ParameterPatchView`](@ref) but for accessing the parameter
+components by symbol. Completes the ability to modify parameters as
+```julia
+pv = ParameterPatchView(...)
+pv.a1.K = pv.a2.K * 3 + 2
+```
+"""
+struct ModelPatchView{P<:ParameterPatchView}
+    _parent::P
+    _model::Symbol
+end
+
+Base.propertynames(pv::ParameterPatchView) = getfield(pv, :_symbols)
+Base.propertynames(pv::ModelPatchView) = propertynames(getfield(pv, :_parent))
+
+function Base.getproperty(pv::ModelPatchView, s::Symbol)
+    parent = getfield(pv, :_parent)
+    syms = getfield(parent, :_symbols)
+    for (i, pair) in enumerate(syms)
+        if (first(pair) == getfield(pv, :_model)) && (last(pair) == s)
+            return getfield(parent, :_values)[i]
+        end
+    end
+    error("Model $(getfield(pv, :_model)) has no parameter $(s)")
+end
+
+function Base.setproperty!(pv::ModelPatchView, s::Symbol, value)
+    parent = getfield(pv, :_parent)
+    syms = getfield(parent, :_symbols)
+    for (i, pair) in enumerate(syms)
+        if (first(pair) == getfield(pv, :_model)) && (last(pair) == s)
+            return getfield(parent, :_values)[i] = value
+        end
+    end
+    error("Model $(getfield(pv, :_model)) has no parameter $(s)")
+end
+
+function Base.getproperty(pv::ParameterPatchView, s::Symbol)
+    syms = getfield(pv, :_symbols)
+    for pair in syms
+        if first(pair) == s
+            return ModelPatchView(pv, s)
+        end
+    end
+    error("No such model component $(s)")
+end
+
+"""
+    ParameterPatch(model; patch::Function)
+
+An [`AbstractModelWrapper`](@ref) that can be used to manipulate the parameters
+of the model it wraps. For example
+
+```julia
+model = PowerLaw() + PowerLaw()
+
+function patcher!(p)
+    # any arbitrary function may be defined here
+    p.a1.K = 3 * p.a2.K + sqrt(p.a2.a)
+end
+
+patched_model = ParameterPatch(model; patch = patcher!)
+
+# set the patched parameter as frozen so it is not fitted
+# failing to do so may ruin a fit
+patched_model.a1.K.frozen = true
+```
+
+When the model is invoked, it will call the `patch` function to manipulate the
+parameters as desired.
+
+!!! warning
+
+    This wrapper is relatively new and not extensively tested. It should be
+    noted nothing is done to validate if a parameter that you are modifying is
+    actually a `frozen` parameter. This will change in the future, and
+    parameters patched this way will be labelled as `bound`.
+
+"""
+struct ParameterPatch{M,T,K,F} <: AbstractModelWrapper{M,T,K}
+    model::M
+    symbols::Vector{Pair{Symbol,Symbol}}
+    patch!::F
+    function ParameterPatch(
+        model::AbstractSpectralModel{T,K},
+        symbols,
+        patch!::F,
+    ) where {T,K,F}
+        new{typeof(model),T,K,F}(model, symbols, patch!)
+    end
+end
+
+function remake_with_parameters(
+    model::ParameterPatch{T,K},
+    params::AbstractVector,
+) where {T,K}
+    model.patch!(ParameterPatchView(params, model.symbols))
+    ParameterPatch(remake_with_parameters(model.model, params), model.symbols, model.patch!)
+end
+
+function ParameterPatch(model::AbstractSpectralModel{T,K}; patch::Function) where {T,K}
+    _, syms = _all_parameters_with_symbols(model)
+    ParameterPatch(copy(model), syms, patch)
+end
+
+"""
+    apply_patch!(model::ParameterPatch)
+
+Apply a patch to the model (i.e. use the `patch!` function to update the model
+parameters).
+"""
+function apply_patch!(model::ParameterPatch)
+    pvec = parameter_vector(model.model)
+    params = get_value.(pvec)
+    model.patch!(ParameterPatchView(params, model.symbols))
+    for (v, p) in zip(params, pvec)
+        set_value!(p, v)
+    end
+    model
+end
+
+export ParameterPatch, ParameterPatchView, apply_patch!

--- a/test/models/test-patching.jl
+++ b/test/models/test-patching.jl
@@ -1,0 +1,59 @@
+using Test
+using SpectralFitting
+
+Base.@kwdef struct ModelTester{T} <: AbstractSpectralModel{T,Additive}
+    K::T = FitParam(1.0)
+    p1::T = FitParam(3.0)
+end
+
+function SpectralFitting.invoke!(out, domain, model::ModelTester)
+    @test model.p1 == 5.0
+end
+
+function set_to_five(p)
+    p.a1.p1 = 5.0
+    p.a2.p1 = 5.0
+end
+
+model = ParameterPatch(ModelTester() + ModelTester(); patch = set_to_five)
+
+domain = collect(range(0.1, 10.0, 100))
+invokemodel(domain, model)
+
+# test the same function can be applied to the model
+set_to_five(model)
+@test model.a2.p1 == model.a1.p1
+@test model.a2.p1.value == 5.0
+
+include("../dummies.jl")
+
+model = PowerLaw(; K = FitParam(4.0)) + PowerLaw(; K = FitParam(8.0), a = FitParam(8.0))
+
+function relate_normalisations!(p)
+    p.a1.K = p.a2.K / 2
+end
+
+patched = ParameterPatch(model; patch = relate_normalisations!)
+patched.a1.K.frozen = true
+patched.a1.K = 0
+patched.a2.a.value = 3.0
+
+@test size(SpectralFitting.parameter_vector(patched)) == (4,)
+@test SpectralFitting.parameter_names(patched) == (:K, :a, :K, :a)
+
+domain = collect(range(0.1, 10.0, 100))
+@inferred invokemodel(domain, patched)
+
+dummy_data = make_dummy_dataset(identity; units = u"counts / (keV * s)")
+sim = simulate(model, dummy_data; seed = 42)
+
+prob = FittingProblem(patched => sim)
+details(prob)
+conf = FittingConfig(prob)
+
+result = fit(prob, LevenbergMarquadt())
+
+apply_patch!(patched)
+
+@test result.u ≈ [2.0004, 7.9989, 8.0001] rtol=1e-3
+@test result.stats[1] ≈ 75.639 rtol = 1e-3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ end
     include("models/test-general-models.jl")
     include("models/test-julia-models.jl")
     include("models/test-wrappers.jl")
+    include("models/test-patching.jl")
 end
 
 @testset "io" verbose = true begin


### PR DESCRIPTION
@DariusMichienzi here's the parameter patching. An example:
```julia
model = PowerLaw() + PowerLaw()

function patcher!(p)
    # this can be any arbitrary function, accessing the parameters of the model as you would otherwise
    p.a1.K = p.a2.K / 2
    # even weird things
    p.a1.a = sqrt(p.a2.a) + sin(p.a1.a)
end

patched_model = ParameterPatch(model; patch = patcher!)

# i'd recommend freezing the parameters you patch, to avoid fitting problems
patched_model.a1.K.frozen = true
patched_model.a1.a.frozen = true
```
In the future I'll make it do that freezing automatically.

That's all you need to do. Then use `patched_model` as before!

I haven't programmed the user-interface bits yet, so that or how things are being patched is a little opaque at the moment, but I have added an `apply_patch!` function that you can give a `ParameterPatch` model to. This function will apply whatever your patch function does to your `FitParam` model. In practice, you'd want to do
```julia
result = fit(prob, LevenbergMarquadt())

update_model!(patched_model, result)
apply_patch!(patched_model)
```
And then inspect the overall model as usual.

Hope that helps!